### PR TITLE
Added support for Huawei/Vodafone K5161h 

### DIFF
--- a/services/usb_modeswitch/12d1-1f1d.conf
+++ b/services/usb_modeswitch/12d1-1f1d.conf
@@ -1,0 +1,6 @@
+# Vodafone / Huawei Kxxxx
+DefaultVendor=0x12d1
+DefaultProduct=0x1f1d
+TargetVendor=0x12d1
+TargetProductList="157b,1591"
+HuaweiNewMode=1


### PR DESCRIPTION
Added 12d1:1f1d config file for Huawei/Vodafone K5161h

Based on: https://github.com/lixiantai/usb-modeswitch-data/blob/master/usb_modeswitch.d/12d1:1f1d

To use in combination with https://github.com/tesla-android/android-external-tesla-android-usb-networking-initialiser/pull/1 