### PR TITLE
Keep old bearing value if new one is not available

### DIFF
--- a/hardware/gnss/gnss.cpp
+++ b/hardware/gnss/gnss.cpp
@@ -103,6 +103,7 @@ Return<bool> Gnss20::start() {
     }
 
     mIsActive = true;
+    double bearingDegrees = 0.0;
     mThread = std::thread([this]() {
         while (mIsActive) {
             unsigned short flags =
@@ -129,12 +130,11 @@ Return<bool> Gnss20::start() {
                     flags |= ahg10::GnssLocationFlags::HAS_SPEED;
                 }
 
-                double bearingDegrees = 0.0;
                 if (property_get("persist.tesla-android.gps.bearing", bearingString, "") > 0
                     && std::string(bearingString) != "not-available" && std::isdigit(bearingString[0])) {
                     bearingDegrees = atof(bearingString);
-                    flags |= ahg10::GnssLocationFlags::HAS_BEARING;
                 }
+                flags |= ahg10::GnssLocationFlags::HAS_BEARING;
 
                 ahg10::GnssLocation location = {
                      .gnssLocationFlags = flags,


### PR DESCRIPTION
By not resetting the bearing value when a new one is not available (e.g. the car is stationary so we can't calculate the bearing based on the location difference), we can avoid annoying map rotation in navigation apps like Waze or Yanosik in stop-and-go traffic.