### PR TITLE
Update lighttpd config to support for private IP Address ranges

### DIFF
--- a/services/lighttpd/lighttpd.conf
+++ b/services/lighttpd/lighttpd.conf
@@ -68,7 +68,7 @@ $SERVER["socket"] == ":443" {
     }
 }
 
-$HTTP["host"] =~ "(^|.)teslaandroid\.com$" {
+$HTTP["host"] =~ "(^|.)teslaandroid\.com$|^(192\.168\.[0-9]{1,3}\.[0-9]{1,3}|10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}|172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]{1,3}\.[0-9]{1,3})$" {
     setenv.add-response-header = (
         "Cross-Origin-Embedder-Policy" => "credentialless",
         "Cross-Origin-Opener-Policy" => "same-origin",


### PR DESCRIPTION
I sometimes plug in my pi in at home to update via my home router. It would be nice to be able to access the web interface via IP Address.

I currently just update my computer's hosts file for device.teslaandroid.com, but it would be nice to be able to access via IP as well.